### PR TITLE
Fix: require for new namespace

### DIFF
--- a/packages/toast/src/commands/bake.js
+++ b/packages/toast/src/commands/bake.js
@@ -175,7 +175,7 @@ class BakeCommand extends Command {
       .then(() =>
         fs.copyFile(
           path.resolve(
-            path.dirname(path.dirname(require.resolve("@sector/toast"))),
+            path.dirname(path.dirname(require.resolve("toast"))),
             "static/toast/page-renderer.js"
           ),
           path.resolve(publicDir, "toast/page-renderer.js")


### PR DESCRIPTION
closes #15

Used old namespace. Changed to new without `@sector`.