### PR TITLE
fix: pass filename to babel transforms

### DIFF
--- a/packages/toast/src/commands/incremental.js
+++ b/packages/toast/src/commands/incremental.js
@@ -66,7 +66,8 @@ class IncrementalCommand extends Command {
         const fullFilePath = path.resolve(siteDir, filepath);
         const fileContents = await fs.readFile(fullFilePath, "utf-8");
         const browserComponent = await transformComponentForBrowser(
-          fileContents
+          fileContents,
+          fullFilePath
         );
         const browserComponentPath = path.resolve(publicDir, filepath);
         // make sure directory to put file in exists
@@ -77,7 +78,10 @@ class IncrementalCommand extends Command {
             fs.writeFile(browserComponentPath, browserComponent.code, "utf-8")
           );
 
-        const nodeComponent = await transformComponentForNode(fileContents);
+        const nodeComponent = await transformComponentForNode(
+          fileContents,
+          fullFilePath
+        );
         const nodeComponentPath = path.resolve(cacheDir, filepath);
         await fs
           .mkdir(path.dirname(nodeComponentPath), { recursive: true })

--- a/packages/toast/src/transforms.js
+++ b/packages/toast/src/transforms.js
@@ -2,8 +2,9 @@ const { transformAsync } = require("@babel/core");
 const path = require("path");
 // const WebdependenciesAliases = require("./babel/babel-plugin-webdependencies-aliases");
 
-module.exports.transformComponentForBrowser = (mod) =>
+module.exports.transformComponentForBrowser = (mod, filename) =>
   transformAsync(mod, {
+    filename,
     babelrc: false,
     presets: [`@babel/preset-react`],
     plugins: [
@@ -22,8 +23,9 @@ module.exports.transformComponentForBrowser = (mod) =>
     ],
   });
 
-module.exports.transformComponentForNode = (mod) =>
+module.exports.transformComponentForNode = (mod, filename) =>
   transformAsync(mod, {
+    filename,
     babelrc: false,
     presets: [
       [`@babel/preset-env`, { targets: { node: "current" } }],


### PR DESCRIPTION
adds the filename for Babel transforms that expect it, such as `babel-plugin-transform-postcss`