### PR TITLE
Moving globby to a direct dependency

### DIFF
--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -25,6 +25,7 @@
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "chokidar": "^3.3.1",
     "es-module-lexer": "^0.3.17",
+    "globby": "^10",
     "honeycomb-beeline": "^2.0.2",
     "module-alias": "^2.2.2",
     "preact": "^10.3.4",
@@ -32,8 +33,7 @@
     "react-helmet": "^6.0.0-beta.2"
   },
   "devDependencies": {
-    "@oclif/dev-cli": "^1",
-    "globby": "^10"
+    "@oclif/dev-cli": "^1"
   },
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
The dependency was being used in code that is being published as part of toast (ex: the `incremental` command), so I moved it up into the `dependencies` section of the the package.json