### PR TITLE
Update incremental.js to customize Honeycomb dataset name

### DIFF
--- a/packages/toast/src/commands/incremental.js
+++ b/packages/toast/src/commands/incremental.js
@@ -10,7 +10,7 @@ const {
 const { render } = require("../page-renderer-pre");
 const beeline = require("honeycomb-beeline")({
   writeKey: process.env.HONEYCOMB_WRITE_KEY || "no write key",
-  dataset: "serverless",
+  dataset: process.env.HONEYCOMB_DATASET_NAME || "serverless",
   // transmission: process.env.HONEYCOMB_TRANSMISSION  || null
 });
 


### PR DESCRIPTION
Added functionality to pass a `HONEYCOMB_DATASET_NAME` environment variable in when running `toast incremental` to customize the name of the dataset.