### PR TITLE
Changed urls to be relative inside toast's readme.md

### DIFF
--- a/packages/toast/README.md
+++ b/packages/toast/README.md
@@ -53,7 +53,7 @@ DESCRIPTION
 ```
 
 _See code:
-[src/commands/bake.js](https://github.com/ChristopherBiscardi/toast/blob/v0.0.1/src/commands/bake.js)_
+[src/commands/bake.js](./src/commands/bake.js)_
 
 ## `toast chai`
 
@@ -68,7 +68,7 @@ DESCRIPTION
 ```
 
 _See code:
-[src/commands/chai.js](https://github.com/ChristopherBiscardi/toast/blob/v0.0.1/src/commands/chai.js)_
+[src/commands/chai.js](./src/commands/chai.js)_
 
 ## `toast help [COMMAND]`
 
@@ -102,7 +102,7 @@ DESCRIPTION
 ```
 
 _See code:
-[src/commands/incremental.js](https://github.com/ChristopherBiscardi/toast/blob/v0.0.1/src/commands/incremental.js)_
+[src/commands/incremental.js](./src/commands/incremental.js)_
 
 ## `toast shake`
 
@@ -118,6 +118,6 @@ DESCRIPTION
 ```
 
 _See code:
-[src/commands/shake.js](https://github.com/ChristopherBiscardi/toast/blob/v0.0.1/src/commands/shake.js)_
+[src/commands/shake.js](./src/commands/shake.js)_
 
 <!-- commandsstop -->


### PR DESCRIPTION
I just saw that some of the links in the readme.md file returned 404.
I've created a pull-request in the case you wanted these to be relative urls.

Looking forward to seeing the future of this project!