### PR TITLE
Catch error if no page-wrapper.js supplied

### DIFF
--- a/packages/toast/src/page-renderer-pre.js
+++ b/packages/toast/src/page-renderer-pre.js
@@ -15,7 +15,7 @@ const htmlTemplate = ({
 }) => `<!DOCTYPE html>
 <script>
 window.componentPath = "${componentPath}";
-window.wrapperComponentPath = "${pageWrapperPath}";
+window.wrapperComponentPath = ${pageWrapperPath && `"${pageWrapperPath}"`};
 window.dataPath = ${dataPath && `"${dataPath}"`};
 </script>
 <html ${helmet.htmlAttributes.toString()}>
@@ -78,6 +78,9 @@ exports.render = async ({
   browserPageWrapperPath,
   browserDataPath
 }) => {
+  browserPageWrapperPath = pageWrapper ? browserPageWrapperPath : undefined;
+  pageWrapper = pageWrapper ? pageWrapper : ({children}) => h('div', null, children);
+  
   const output = render(h(pageWrapper, data, h(component, data)));
   //   console.log(output);
   const helmet = Helmet.renderStatic();


### PR DESCRIPTION
This provides some error checking in the case that a `page-wrapper.js` file is not provided.

Fixes #25 