### PR TITLE
feat: support noscript tags in static output

### DIFF
--- a/packages/toast/src/page-renderer-pre.js
+++ b/packages/toast/src/page-renderer-pre.js
@@ -24,6 +24,7 @@ window.dataPath = ${dataPath && `"${dataPath}"`};
   ${helmet.meta.toString()}
   ${helmet.link.toString()}
   ${helmet.noscript.toString()}
+  ${helmet.noscript.toString()}
   </head>
   <body ${helmet.bodyAttributes.toString()}>
     <div id="toast-page-section">${appHtml}</div>

--- a/packages/toast/src/page-renderer-pre.js
+++ b/packages/toast/src/page-renderer-pre.js
@@ -1,6 +1,6 @@
-const { render } = require("preact-render-to-string");
-const { h } = require("preact");
-const { Helmet } = require("react-helmet");
+const { render } = require('preact-render-to-string');
+const { h } = require('preact');
+const { Helmet } = require('react-helmet');
 // const babel = require("@babel/core");
 // const vm = require("vm");
 // const { MDXProvider } = require("@mdx-js/preact");
@@ -11,7 +11,7 @@ const htmlTemplate = ({
   pageWrapperPath,
   dataPath,
   appHtml,
-  helmet
+  helmet,
 }) => `<!DOCTYPE html>
 <script>
 window.componentPath = "${componentPath}";
@@ -23,6 +23,7 @@ window.dataPath = ${dataPath && `"${dataPath}"`};
   ${helmet.title.toString()}
   ${helmet.meta.toString()}
   ${helmet.link.toString()}
+  ${helmet.noscript.toString()}
   </head>
   <body ${helmet.bodyAttributes.toString()}>
     <div id="toast-page-section">${appHtml}</div>
@@ -68,7 +69,7 @@ renderPage();
 </html>
 `;
 
-const windowsLocalDevPathReplacement = /\\/g
+const windowsLocalDevPathReplacement = /\\/g;
 
 exports.render = async ({
   component,
@@ -76,19 +77,27 @@ exports.render = async ({
   data = {},
   browserComponentPath,
   browserPageWrapperPath,
-  browserDataPath
+  browserDataPath,
 }) => {
   browserPageWrapperPath = pageWrapper ? browserPageWrapperPath : undefined;
-  pageWrapper = pageWrapper ? pageWrapper : ({children}) => h('div', null, children);
-  
+  pageWrapper = pageWrapper
+    ? pageWrapper
+    : ({ children }) => h('div', null, children);
+
   const output = render(h(pageWrapper, data, h(component, data)));
   //   console.log(output);
   const helmet = Helmet.renderStatic();
   return htmlTemplate({
-    componentPath: browserComponentPath.replace(windowsLocalDevPathReplacement, "/"),
+    componentPath: browserComponentPath.replace(
+      windowsLocalDevPathReplacement,
+      '/',
+    ),
     pageWrapperPath: browserPageWrapperPath,
-    dataPath: Object.keys(data).length > 0 ? browserDataPath.replace(windowsLocalDevPathReplacement, "/") : undefined,
+    dataPath:
+      Object.keys(data).length > 0
+        ? browserDataPath.replace(windowsLocalDevPathReplacement, '/')
+        : undefined,
     appHtml: output,
-    helmet
+    helmet,
   });
 };

--- a/packages/toast/src/page-renderer-pre.js
+++ b/packages/toast/src/page-renderer-pre.js
@@ -1,6 +1,6 @@
-const { render } = require('preact-render-to-string');
-const { h } = require('preact');
-const { Helmet } = require('react-helmet');
+const { render } = require("preact-render-to-string");
+const { h } = require("preact");
+const { Helmet } = require("react-helmet");
 // const babel = require("@babel/core");
 // const vm = require("vm");
 // const { MDXProvider } = require("@mdx-js/preact");
@@ -11,7 +11,7 @@ const htmlTemplate = ({
   pageWrapperPath,
   dataPath,
   appHtml,
-  helmet,
+  helmet
 }) => `<!DOCTYPE html>
 <script>
 window.componentPath = "${componentPath}";
@@ -23,7 +23,6 @@ window.dataPath = ${dataPath && `"${dataPath}"`};
   ${helmet.title.toString()}
   ${helmet.meta.toString()}
   ${helmet.link.toString()}
-  ${helmet.noscript.toString()}
   ${helmet.noscript.toString()}
   </head>
   <body ${helmet.bodyAttributes.toString()}>
@@ -70,7 +69,7 @@ renderPage();
 </html>
 `;
 
-const windowsLocalDevPathReplacement = /\\/g;
+const windowsLocalDevPathReplacement = /\\/g
 
 exports.render = async ({
   component,
@@ -78,27 +77,19 @@ exports.render = async ({
   data = {},
   browserComponentPath,
   browserPageWrapperPath,
-  browserDataPath,
+  browserDataPath
 }) => {
   browserPageWrapperPath = pageWrapper ? browserPageWrapperPath : undefined;
-  pageWrapper = pageWrapper
-    ? pageWrapper
-    : ({ children }) => h('div', null, children);
-
+  pageWrapper = pageWrapper ? pageWrapper : ({children}) => h('div', null, children);
+  
   const output = render(h(pageWrapper, data, h(component, data)));
   //   console.log(output);
   const helmet = Helmet.renderStatic();
   return htmlTemplate({
-    componentPath: browserComponentPath.replace(
-      windowsLocalDevPathReplacement,
-      '/',
-    ),
+    componentPath: browserComponentPath.replace(windowsLocalDevPathReplacement, "/"),
     pageWrapperPath: browserPageWrapperPath,
-    dataPath:
-      Object.keys(data).length > 0
-        ? browserDataPath.replace(windowsLocalDevPathReplacement, '/')
-        : undefined,
+    dataPath: Object.keys(data).length > 0 ? browserDataPath.replace(windowsLocalDevPathReplacement, "/") : undefined,
     appHtml: output,
-    helmet,
+    helmet
   });
 };


### PR DESCRIPTION
I ran into a use case where I need styles for JS-enabled browsers that need to be unset if JS is disabled. currently `<noscript>` tags aren't injected during the Toast build, so this PR adds those

I've tested this working on the new LWJ site